### PR TITLE
fix: fix non whole positions

### DIFF
--- a/src/lib/components/game/PlayerEditor.svelte
+++ b/src/lib/components/game/PlayerEditor.svelte
@@ -32,7 +32,7 @@
 			}}
             onPlayerAdd={(player) => {
                 player.position = Math.min(
-					players.map(p => p.position).reduce((a, b) => a + b, 0) / (players.length), 
+					Math.floor(players.map(p => p.position).reduce((a, b) => a + b, 0) / (players.length)), 
 					// Joining player cannot instantly win
 					lastTilePosition - 1);
                 return player;


### PR DESCRIPTION
When a new player is added, their position might not be an integer, which results in the tiles not showing