### PR TITLE
feat: persist multiplayer join code and show rejoin action on setup

### DIFF
--- a/e2e/demo.test.ts
+++ b/e2e/demo.test.ts
@@ -143,13 +143,16 @@ async function startMultiplayerGameInBrowser(
 	let guestPlayerId: string | null = null;
 
 	await expect
-		.poll(async () => {
-			const state = await getExposedState(hostPage);
-			hostPlayerId = state.players.find((player) => player.name === 'Host')?.id ?? null;
-			guestPlayerId = state.players.find((player) => player.name === 'Guest')?.id ?? null;
+		.poll(
+			async () => {
+				const state = await getExposedState(hostPage);
+				hostPlayerId = state.players.find((player) => player.name === 'Host')?.id ?? null;
+				guestPlayerId = state.players.find((player) => player.name === 'Guest')?.id ?? null;
 
-			return Boolean(hostPlayerId && guestPlayerId);
-		}, { timeout: 15_000 })
+				return Boolean(hostPlayerId && guestPlayerId);
+			},
+			{ timeout: 15_000 }
+		)
 		.toBe(true);
 
 	return {
@@ -177,6 +180,43 @@ test('can switch between single and multiplayer setup modes', async ({ page }) =
 	await expect(page.getByRole('heading', { name: 'Monen laitteen peli (Beta)' })).toBeVisible();
 	await expect(page.getByRole('button', { name: 'Hostaa peli' })).toBeVisible();
 	await expect(page.getByRole('button', { name: 'Liity peliin' })).toBeVisible();
+});
+
+test('rejoin helper stores join code and lets player join from front page after reload', async ({
+	browser
+}) => {
+	test.setTimeout(90_000);
+
+	const hostContext = await browser.newContext();
+	const rejoinContext = await browser.newContext();
+	const hostPage = await hostContext.newPage();
+	const rejoinPage = await rejoinContext.newPage();
+
+	await hostPage.goto('/?e2e=1');
+	await rejoinPage.goto('/?e2e=1');
+
+	await hostPage.getByRole('button', { name: 'Monen laitteen peli (Beta)' }).click();
+	await hostPage.getByRole('button', { name: 'Hostaa peli' }).click();
+	const code = await createLobbyAndReadCode(hostPage);
+
+	await rejoinPage.getByRole('button', { name: 'Monen laitteen peli (Beta)' }).click();
+	await rejoinPage.getByRole('button', { name: 'Liity peliin' }).click();
+	await joinLobbyWithCode(rejoinPage, code);
+	await hostPage.getByRole('button', { name: 'Aloita monen laitteen peli' }).click();
+
+	await rejoinPage.reload();
+	await expect(
+		rejoinPage.getByAltText('Gorilla Blackout - rankka juomapeli opiskelijoille!')
+	).toBeVisible();
+	await rejoinPage.getByRole('button', { name: 'Monen laitteen peli (Beta)' }).click();
+	await expect(rejoinPage.getByTestId('rejoin-lobby')).toContainText(code);
+	await rejoinPage.getByTestId('rejoin-lobby').click();
+	await expect(rejoinPage.locator('#multi-code')).toHaveValue(code);
+	await joinLobbyWithCode(rejoinPage, code);
+	await expect(rejoinPage.getByText(`Koodi: ${code}`)).toBeVisible({ timeout: 15_000 });
+
+	await hostContext.close();
+	await rejoinContext.close();
 });
 
 test('join flow asks for code only after selecting join mode', async ({ page }) => {
@@ -706,7 +746,9 @@ test('single-device player menu can quit the game', async ({ page }) => {
 	await expect(page.getByRole('button', { name: 'Aloita peli' })).toBeVisible({ timeout: 15_000 });
 });
 
-test('single-device player menu supports rename, character change, and remove', async ({ page }) => {
+test('single-device player menu supports rename, character change, and remove', async ({
+	page
+}) => {
 	await page.goto('/?e2e=1');
 	await page.getByLabel('Nimi').nth(0).fill('Alpha');
 	await page.getByLabel('Nimi').nth(1).fill('Beta');

--- a/src/lib/components/game/MultiplayerSetup.svelte
+++ b/src/lib/components/game/MultiplayerSetup.svelte
@@ -12,6 +12,7 @@
 		updateLobbyPlayer
 	} from '$lib/multiplayer/client';
 	import { getJoinCodeFromSearch } from '$lib/multiplayer/invite';
+	import { loadRejoinCode } from '$lib/multiplayer/rejoin';
 	import { isValidLobbyCode, normalizeLobbyCode } from '$lib/multiplayer/lobbyCode';
 	import { gameStateStore } from '$lib/gameState.svelte';
 	import { playerImages } from './playerImages';
@@ -26,6 +27,7 @@
 	let localName = $state('Pelaaja');
 	let localImage = $state<PlayerImage>('default');
 	let appliedJoinCode = $state(false);
+	let rejoinCode = $state<string | null>(null);
 
 	const usedImages = $derived.by(() => {
 		const localPlayerId = $multiplayerStore.playerId;
@@ -34,6 +36,23 @@
 				.filter((player) => player.id !== localPlayerId && player.image !== 'default')
 				.map((player) => player.image)
 		);
+	});
+
+	$effect(() => {
+		if (typeof window === 'undefined' || appliedJoinCode) return;
+
+		loadRejoinCode()
+			.then((storedCode) => {
+				if (appliedJoinCode || !storedCode) return;
+				rejoinCode = storedCode;
+				if (!$multiplayerStore.lobby && setupMode === null) {
+					setupMode = 'join';
+					code = storedCode;
+				}
+			})
+			.catch(() => {
+				rejoinCode = null;
+			});
 	});
 
 	$effect(() => {
@@ -129,6 +148,17 @@
 				onclick={() => (setupMode = 'join')}>Liity peliin</Button
 			>
 		</div>
+
+		{#if rejoinCode}
+			<Button
+				variant="secondary"
+				data-testid="rejoin-lobby"
+				onclick={() => {
+					setupMode = 'join';
+					code = rejoinCode ?? '';
+				}}>Liity aiempaan peliin ({rejoinCode})</Button
+			>
+		{/if}
 
 		{#if setupMode === 'host'}
 			<Button onclick={onCreate}>Luo peli</Button>

--- a/src/lib/components/game/MultiplayerSetup.svelte
+++ b/src/lib/components/game/MultiplayerSetup.svelte
@@ -28,6 +28,7 @@
 	let localImage = $state<PlayerImage>('default');
 	let appliedJoinCode = $state(false);
 	let rejoinCode = $state<string | null>(null);
+	let loadedRejoinCode = $state(false);
 
 	const usedImages = $derived.by(() => {
 		const localPlayerId = $multiplayerStore.playerId;
@@ -39,16 +40,13 @@
 	});
 
 	$effect(() => {
-		if (typeof window === 'undefined' || appliedJoinCode) return;
+		if (typeof window === 'undefined' || loadedRejoinCode) return;
+		loadedRejoinCode = true;
 
 		loadRejoinCode()
 			.then((storedCode) => {
-				if (appliedJoinCode || !storedCode) return;
+				if (!storedCode) return;
 				rejoinCode = storedCode;
-				if (!$multiplayerStore.lobby && setupMode === null) {
-					setupMode = 'join';
-					code = storedCode;
-				}
 			})
 			.catch(() => {
 				rejoinCode = null;

--- a/src/lib/multiplayer/__tests__/rejoin.test.ts
+++ b/src/lib/multiplayer/__tests__/rejoin.test.ts
@@ -1,0 +1,15 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseRejoinCode } from '../rejoin';
+
+describe('multiplayer rejoin helpers', () => {
+	it('normalizes stored codes', () => {
+		assert.equal(parseRejoinCode('abc123'), 'ABC123');
+	});
+
+	it('returns null for invalid values', () => {
+		assert.equal(parseRejoinCode('abc'), null);
+		assert.equal(parseRejoinCode(123), null);
+		assert.equal(parseRejoinCode(undefined), null);
+	});
+});

--- a/src/lib/multiplayer/client.ts
+++ b/src/lib/multiplayer/client.ts
@@ -1,6 +1,7 @@
 import { writable, get } from 'svelte/store';
 import { io, type Socket } from 'socket.io-client';
 import { clearGameState, gameStateStore, type GameState } from '$lib/gameState.svelte';
+import { clearRejoinCode, saveRejoinCode } from './rejoin';
 
 export type GameMode = 'single' | 'multi';
 
@@ -64,6 +65,7 @@ export async function createLobby(name: string, image: string) {
 		isHost: true,
 		lobby: payload.lobby
 	}));
+	await saveRejoinCode(payload.code);
 	connect();
 }
 
@@ -80,6 +82,7 @@ export async function joinLobby(code: string, name: string, image: string) {
 		isHost: false,
 		lobby: payload.lobby
 	}));
+	await saveRejoinCode(payload.code);
 	connect();
 }
 
@@ -110,6 +113,7 @@ export async function removeLobbyPlayer(targetPlayerId: string) {
 	if (payload.removedPlayerId === session.playerId || payload.lobbyClosed) {
 		disconnectAndResetSession('single');
 		clearGameState();
+		await clearRejoinCode();
 		return;
 	}
 
@@ -133,6 +137,7 @@ export async function quitCurrentGame() {
 
 	disconnectAndResetSession('single');
 	clearGameState();
+	await clearRejoinCode();
 }
 
 function connect() {
@@ -149,6 +154,7 @@ function connect() {
 	socket.on('lobby:closed', () => {
 		disconnectAndResetSession('single');
 		clearGameState();
+		void clearRejoinCode();
 	});
 	socket.on('lobby:player-removed', (payload: { playerId?: string }) => {
 		const removedPlayerId = payload?.playerId;
@@ -156,6 +162,7 @@ function connect() {
 		if (removedPlayerId !== session.playerId) return;
 		disconnectAndResetSession('single');
 		clearGameState();
+		void clearRejoinCode();
 	});
 	socket.on('game:state', (state: GameState) => {
 		const enteringRollingPhase =

--- a/src/lib/multiplayer/rejoin.ts
+++ b/src/lib/multiplayer/rejoin.ts
@@ -1,0 +1,25 @@
+import { getItem, removeItem, setItem } from '$lib/helpers/indexedDB';
+import { isValidLobbyCode, normalizeLobbyCode } from './lobbyCode';
+
+const REJOIN_CODE_KEY = 'multiplayerRejoinCode';
+
+export async function saveRejoinCode(code: string): Promise<void> {
+	await setItem(REJOIN_CODE_KEY, normalizeLobbyCode(code));
+}
+
+export function parseRejoinCode(value: unknown): string | null {
+	if (typeof value !== 'string' || !isValidLobbyCode(value)) {
+		return null;
+	}
+
+	return normalizeLobbyCode(value);
+}
+
+export async function loadRejoinCode(): Promise<string | null> {
+	const code = await getItem<string>(REJOIN_CODE_KEY);
+	return parseRejoinCode(code);
+}
+
+export async function clearRejoinCode(): Promise<void> {
+	await removeItem(REJOIN_CODE_KEY);
+}


### PR DESCRIPTION
### Motivation

- Let players return to the front page and explicitly rejoin a multiplayer game they were previously in by persisting the join code locally. 
- Ensure stale codes are removed when the user leaves or the lobby closes so the rejoin action remains accurate.

### Description

- Add `src/lib/multiplayer/rejoin.ts` with `saveRejoinCode`, `loadRejoinCode`, `parseRejoinCode`, and `clearRejoinCode` helpers that use `IndexedDB` via `src/lib/helpers/indexedDB`. 
- Persist the lobby code on lobby creation and join, and clear it when the player quits, is removed, or the lobby closes by updating `src/lib/multiplayer/client.ts`. 
- Surface a front-page rejoin action in `src/lib/components/game/MultiplayerSetup.svelte` that loads the stored code, shows a `Liity aiempaan peliin` button, and pre-fills the join input when used. 
- Add unit tests `src/lib/multiplayer/__tests__/rejoin.test.ts` for parsing/normalization and an e2e Playwright test in `e2e/demo.test.ts` that covers reload + rejoin flow.

### Testing

- Ran unit tests with `pnpm test:unit` and they passed successfully. 
- Added an e2e Playwright test and attempted to run it with `pnpm exec playwright test -g "rejoin helper stores join code"`, but the run was unstable in this environment (initially required `pnpm exec playwright install` and `pnpm exec playwright install-deps chromium`). 
- After installing browsers and dependencies the e2e run hit a runtime browser crash (SIGSEGV) in this container so the e2e assertion could not be completed here; the test itself is included and should be stable when run in CI or a developer machine with Playwright browsers available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3d1f984ec832bb88c49c08880de2a)