### PR TITLE
Harden Socket.IO payload validation to prevent backend crashes

### DIFF
--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -2,36 +2,15 @@ import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import { Server } from 'socket.io';
 import { z } from 'zod';
+import { gameRollRequestSchema, gameStateUpdateSchema } from './socketPayload.js';
 import { randomUUID } from 'node:crypto';
 const port = Number(process.env.PORT ?? 3001);
 const app = Fastify({ logger: true });
 await app.register(cors, { origin: true });
+const io = new Server(app.server, { cors: { origin: '*' } });
 const playerSchema = z.object({
     name: z.string().min(1).max(100),
     image: z.string().min(1)
-});
-const gamePlayerSchema = z.object({
-    id: z.string(),
-    name: z.string(),
-    image: z.string(),
-    position: z.number().int().nonnegative()
-});
-const gameStateSchema = z.object({
-    players: z.array(gamePlayerSchema),
-    turn: z.number().int().nonnegative(),
-    currentTurnPlayerId: z.string().nullable(),
-    turnInProgress: z.boolean(),
-    turnOwnerId: z.string().nullable(),
-    phase: z.enum(['idle', 'rolling', 'tile']),
-    activeTilePosition: z.number().int().nonnegative().nullable(),
-    activeTileTrigger: z.enum(['landing', 'moveStart']).nullable(),
-    activeTileSessionId: z.number().int().nonnegative(),
-    diceValue: z.number().int().min(1).max(6).nullable(),
-    tileState: z.record(z.string(), z.unknown()).nullable(),
-    inGame: z.boolean(),
-    spacebarTooltipShown: z.boolean(),
-    version: z.number(),
-    versionAvailable: z.string().nullable()
 });
 const lobbies = new Map();
 const maxLateJoinPosition = 54;
@@ -78,6 +57,78 @@ function hasDuplicateImage(lobby, playerId, image) {
     if (image === 'default')
         return false;
     return lobby.players.some((player) => player.id !== playerId && player.image === image);
+}
+function removePlayerFromLobby(lobby, targetPlayerId) {
+    const removedWasHost = lobby.hostId === targetPlayerId;
+    const nextPlayers = lobby.players.filter((player) => player.id !== targetPlayerId);
+    if (nextPlayers.length === lobby.players.length) {
+        return {
+            removed: false,
+            removedWasHost,
+            hostReassigned: false,
+            lobbyClosed: false,
+            gameEnded: false
+        };
+    }
+    lobby.players = nextPlayers;
+    const lobbyClosed = lobby.players.length === 0;
+    if (lobbyClosed) {
+        lobby.inGame = false;
+        lobby.state = null;
+        lobby.pendingRoll = null;
+        return {
+            removed: true,
+            removedWasHost,
+            hostReassigned: false,
+            lobbyClosed: true,
+            gameEnded: false
+        };
+    }
+    let hostReassigned = false;
+    if (removedWasHost) {
+        hostReassigned = true;
+        lobby.hostId = lobby.players[0].id;
+    }
+    const gameEnded = false;
+    if (lobby.state) {
+        const remainingStatePlayers = lobby.state.players.filter((player) => player.id !== targetPlayerId);
+        let nextTurnInProgress = lobby.state.turnInProgress;
+        let nextTurnOwnerId = lobby.state.turnOwnerId;
+        let nextCurrentTurnPlayerId = lobby.state.currentTurnPlayerId;
+        let nextPhase = lobby.state.phase;
+        let nextActiveTilePosition = lobby.state.activeTilePosition;
+        let nextActiveTileTrigger = lobby.state.activeTileTrigger;
+        let nextDiceValue = lobby.state.diceValue;
+        if (nextTurnOwnerId === targetPlayerId) {
+            nextTurnInProgress = false;
+            nextTurnOwnerId = null;
+            nextPhase = 'idle';
+            nextActiveTilePosition = null;
+            nextActiveTileTrigger = null;
+            nextDiceValue = null;
+        }
+        if (nextCurrentTurnPlayerId === targetPlayerId) {
+            nextCurrentTurnPlayerId = remainingStatePlayers[0]?.id ?? null;
+        }
+        lobby.state = {
+            ...lobby.state,
+            players: remainingStatePlayers,
+            turnInProgress: nextTurnInProgress,
+            turnOwnerId: nextTurnOwnerId,
+            currentTurnPlayerId: nextCurrentTurnPlayerId,
+            phase: nextPhase,
+            activeTilePosition: nextActiveTilePosition,
+            activeTileTrigger: nextActiveTileTrigger,
+            diceValue: nextDiceValue
+        };
+    }
+    return {
+        removed: true,
+        removedWasHost,
+        hostReassigned,
+        lobbyClosed: false,
+        gameEnded
+    };
 }
 app.post('/api/lobbies', async (request, reply) => {
     const parsed = playerSchema.safeParse(request.body);
@@ -165,6 +216,53 @@ app.post('/api/lobbies/:code/player', async (request, reply) => {
     broadcastGameState(lobby);
     return { lobby: publicLobby(lobby) };
 });
+app.post('/api/lobbies/:code/player/remove', async (request, reply) => {
+    const code = request.params.code.toUpperCase();
+    const lobby = lobbies.get(code);
+    if (!lobby)
+        return reply.code(404).send({ error: 'Lobby not found' });
+    const actorId = request.body?.actorId;
+    const targetPlayerId = request.body?.targetPlayerId;
+    if (!actorId || !targetPlayerId) {
+        return reply.code(400).send({ error: 'actorId and targetPlayerId required' });
+    }
+    const actor = lobby.players.find((player) => player.id === actorId);
+    if (!actor)
+        return reply.code(403).send({ error: 'Actor not in lobby' });
+    const target = lobby.players.find((player) => player.id === targetPlayerId);
+    if (!target)
+        return reply.code(404).send({ error: 'Player not found' });
+    const actorIsHost = lobby.hostId === actorId;
+    const actorRemovingSelf = actorId === targetPlayerId;
+    if (!actorIsHost && !actorRemovingSelf) {
+        return reply.code(403).send({ error: 'Not allowed to remove player' });
+    }
+    const result = removePlayerFromLobby(lobby, targetPlayerId);
+    if (!result.removed) {
+        return reply.code(404).send({ error: 'Player not found' });
+    }
+    if (result.lobbyClosed) {
+        io.to(code).emit('lobby:closed');
+        lobbies.delete(code);
+        return {
+            lobby: null,
+            removedPlayerId: targetPlayerId,
+            lobbyClosed: true,
+            hostReassigned: false,
+            gameEnded: result.gameEnded
+        };
+    }
+    broadcastLobby(lobby);
+    io.to(code).emit('lobby:player-removed', { playerId: targetPlayerId });
+    broadcastGameState(lobby);
+    return {
+        lobby: publicLobby(lobby),
+        removedPlayerId: targetPlayerId,
+        lobbyClosed: false,
+        hostReassigned: result.hostReassigned,
+        gameEnded: result.gameEnded
+    };
+});
 app.get('/api/lobbies/:code', async (request, reply) => {
     const lobby = lobbies.get(request.params.code.toUpperCase());
     if (!lobby)
@@ -188,7 +286,6 @@ app.post('/api/lobbies/:code/start', async (request, reply) => {
     return { lobby: publicLobby(lobby), state: lobby.state };
 });
 const server = await app.listen({ port, host: '0.0.0.0' });
-const io = new Server(app.server, { cors: { origin: '*' } });
 io.on('connection', (socket) => {
     const code = socket.handshake.auth.code?.toUpperCase();
     const playerId = socket.handshake.auth.playerId;
@@ -206,13 +303,12 @@ io.on('connection', (socket) => {
     if (lobby.state)
         socket.emit('game:state', lobby.state);
     socket.on('game:state:update', (payload) => {
-        if (!lobby.inGame || !payload)
+        if (!lobby.inGame)
             return;
-        if (payload.actorId !== playerId)
+        const parsedPayload = gameStateUpdateSchema.safeParse(payload);
+        if (!parsedPayload.success)
             return;
-        const candidateState = payload.state;
-        const parsedState = gameStateSchema.safeParse(candidateState);
-        if (!parsedState.success)
+        if (parsedPayload.data.actorId !== playerId)
             return;
         const previous = lobby.state;
         const allowedActor = previous?.turnInProgress
@@ -220,8 +316,8 @@ io.on('connection', (socket) => {
             : previous?.currentTurnPlayerId;
         if (allowedActor && allowedActor !== playerId)
             return;
-        lobby.state = parsedState.data;
-        lobby.players = parsedState.data.players.map((player) => ({ ...player }));
+        lobby.state = parsedPayload.data.state;
+        lobby.players = parsedPayload.data.state.players.map((player) => ({ ...player }));
         if (lobby.state.diceValue !== null) {
             lobby.pendingRoll = null;
         }
@@ -230,7 +326,10 @@ io.on('connection', (socket) => {
     socket.on('game:roll:request', (payload) => {
         if (!lobby.inGame || !lobby.state)
             return;
-        if (payload.actorId !== playerId)
+        const parsedPayload = gameRollRequestSchema.safeParse(payload);
+        if (!parsedPayload.success)
+            return;
+        if (parsedPayload.data.actorId !== playerId)
             return;
         const allowedActor = lobby.state.turnInProgress
             ? lobby.state.turnOwnerId

--- a/backend/dist/socketPayload.js
+++ b/backend/dist/socketPayload.js
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+export const gamePlayerSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    image: z.string(),
+    position: z.number().int().nonnegative()
+});
+export const gameStateSchema = z.object({
+    players: z.array(gamePlayerSchema),
+    turn: z.number().int().nonnegative(),
+    currentTurnPlayerId: z.string().nullable(),
+    turnInProgress: z.boolean(),
+    turnOwnerId: z.string().nullable(),
+    phase: z.enum(['idle', 'rolling', 'tile']),
+    activeTilePosition: z.number().int().nonnegative().nullable(),
+    activeTileTrigger: z.enum(['landing', 'moveStart']).nullable(),
+    activeTileSessionId: z.number().int().nonnegative(),
+    diceValue: z.number().int().min(1).max(6).nullable(),
+    tileState: z.record(z.string(), z.unknown()).nullable(),
+    inGame: z.boolean(),
+    spacebarTooltipShown: z.boolean(),
+    version: z.number(),
+    versionAvailable: z.string().nullable()
+});
+export const gameStateUpdateSchema = z.object({
+    actorId: z.string(),
+    state: gameStateSchema
+});
+export const gameRollRequestSchema = z.object({
+    actorId: z.string()
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,23 +1,24 @@
 {
-	"name": "gorilla-blackout-backend",
-	"version": "0.1.0",
-	"private": true,
-	"type": "module",
-	"scripts": {
-		"dev": "tsx watch src/index.ts",
-		"build": "tsc -p tsconfig.json",
-		"start": "node dist/index.js",
-		"check": "tsc --noEmit -p tsconfig.json"
-	},
-	"dependencies": {
-		"@fastify/cors": "^10.0.1",
-		"fastify": "^5.0.0",
-		"socket.io": "^4.8.1",
-		"zod": "^3.25.76"
-	},
-	"devDependencies": {
-		"@types/node": "^24.3.0",
-		"tsx": "^4.20.4",
-		"typescript": "^5.9.2"
-	}
+  "name": "gorilla-blackout-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "check": "tsc --noEmit -p tsconfig.json",
+    "test": "tsx --test src/**/__tests__/*.test.ts"
+  },
+  "dependencies": {
+    "@fastify/cors": "^10.0.1",
+    "fastify": "^5.0.0",
+    "socket.io": "^4.8.1",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "tsx": "^4.20.4",
+    "typescript": "^5.9.2"
+  }
 }

--- a/backend/src/__tests__/socketPayload.test.ts
+++ b/backend/src/__tests__/socketPayload.test.ts
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { gameRollRequestSchema, gameStateUpdateSchema } from '../socketPayload.js';
+
+const validState = {
+	players: [
+		{
+			id: 'p1',
+			name: 'Player 1',
+			image: 'default',
+			position: 0
+		}
+	],
+	turn: 0,
+	currentTurnPlayerId: 'p1',
+	turnInProgress: false,
+	turnOwnerId: null,
+	phase: 'idle',
+	activeTilePosition: null,
+	activeTileTrigger: null,
+	activeTileSessionId: 0,
+	diceValue: null,
+	tileState: null,
+	inGame: true,
+	spacebarTooltipShown: false,
+	version: 1,
+	versionAvailable: null
+};
+
+test('game roll request schema rejects null payloads', () => {
+	const result = gameRollRequestSchema.safeParse(null);
+	assert.equal(result.success, false);
+});
+
+test('game roll request schema accepts actor payload', () => {
+	const result = gameRollRequestSchema.safeParse({ actorId: 'p1' });
+	assert.equal(result.success, true);
+});
+
+test('game state update schema rejects malformed updates', () => {
+	const result = gameStateUpdateSchema.safeParse({ actorId: 'p1', state: null });
+	assert.equal(result.success, false);
+});
+
+test('game state update schema accepts valid state updates', () => {
+	const result = gameStateUpdateSchema.safeParse({ actorId: 'p1', state: validState });
+	assert.equal(result.success, true);
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,45 +2,25 @@ import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import { Server } from 'socket.io';
 import { z } from 'zod';
+import {
+	gameRollRequestSchema,
+	gameStateSchema,
+	gameStateUpdateSchema,
+	type GameState
+} from './socketPayload.js';
 import { randomUUID } from 'node:crypto';
 
 const port = Number(process.env.PORT ?? 3001);
 const app = Fastify({ logger: true });
 await app.register(cors, { origin: true });
+const io = new Server(app.server, { cors: { origin: '*' } });
 
 const playerSchema = z.object({
 	name: z.string().min(1).max(100),
 	image: z.string().min(1)
 });
 
-const gamePlayerSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	image: z.string(),
-	position: z.number().int().nonnegative()
-});
-
-const gameStateSchema = z.object({
-	players: z.array(gamePlayerSchema),
-	turn: z.number().int().nonnegative(),
-	currentTurnPlayerId: z.string().nullable(),
-	turnInProgress: z.boolean(),
-	turnOwnerId: z.string().nullable(),
-	phase: z.enum(['idle', 'rolling', 'tile']),
-	activeTilePosition: z.number().int().nonnegative().nullable(),
-	activeTileTrigger: z.enum(['landing', 'moveStart']).nullable(),
-	activeTileSessionId: z.number().int().nonnegative(),
-	diceValue: z.number().int().min(1).max(6).nullable(),
-	tileState: z.record(z.string(), z.unknown()).nullable(),
-	inGame: z.boolean(),
-	spacebarTooltipShown: z.boolean(),
-	version: z.number(),
-	versionAvailable: z.string().nullable()
-});
-
 type Player = z.infer<typeof playerSchema> & { id: string; position: number };
-type GameState = z.infer<typeof gameStateSchema>;
-
 type Lobby = {
 	code: string;
 	hostId: string;
@@ -368,7 +348,6 @@ app.post<{ Params: { code: string }; Body: { playerId?: string } }>(
 );
 
 const server = await app.listen({ port, host: '0.0.0.0' });
-const io = new Server(app.server, { cors: { origin: '*' } });
 
 io.on('connection', (socket) => {
 	const code = (socket.handshake.auth.code as string | undefined)?.toUpperCase();
@@ -387,12 +366,11 @@ io.on('connection', (socket) => {
 	if (lobby.state) socket.emit('game:state', lobby.state);
 
 	socket.on('game:state:update', (payload) => {
-		if (!lobby.inGame || !payload) return;
-		if ((payload as { actorId?: string }).actorId !== playerId) return;
+		if (!lobby.inGame) return;
 
-		const candidateState = (payload as { state?: unknown }).state;
-		const parsedState = gameStateSchema.safeParse(candidateState);
-		if (!parsedState.success) return;
+		const parsedPayload = gameStateUpdateSchema.safeParse(payload);
+		if (!parsedPayload.success) return;
+		if (parsedPayload.data.actorId !== playerId) return;
 
 		const previous = lobby.state;
 		const allowedActor = previous?.turnInProgress
@@ -400,8 +378,8 @@ io.on('connection', (socket) => {
 			: previous?.currentTurnPlayerId;
 		if (allowedActor && allowedActor !== playerId) return;
 
-		lobby.state = parsedState.data;
-		lobby.players = parsedState.data.players.map((player) => ({ ...player }));
+		lobby.state = parsedPayload.data.state;
+		lobby.players = parsedPayload.data.state.players.map((player) => ({ ...player }));
 		if (lobby.state.diceValue !== null) {
 			lobby.pendingRoll = null;
 		}
@@ -410,7 +388,10 @@ io.on('connection', (socket) => {
 
 	socket.on('game:roll:request', (payload) => {
 		if (!lobby.inGame || !lobby.state) return;
-		if ((payload as { actorId?: string }).actorId !== playerId) return;
+
+		const parsedPayload = gameRollRequestSchema.safeParse(payload);
+		if (!parsedPayload.success) return;
+		if (parsedPayload.data.actorId !== playerId) return;
 
 		const allowedActor = lobby.state.turnInProgress
 			? lobby.state.turnOwnerId

--- a/backend/src/socketPayload.ts
+++ b/backend/src/socketPayload.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+export const gamePlayerSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	image: z.string(),
+	position: z.number().int().nonnegative()
+});
+
+export const gameStateSchema = z.object({
+	players: z.array(gamePlayerSchema),
+	turn: z.number().int().nonnegative(),
+	currentTurnPlayerId: z.string().nullable(),
+	turnInProgress: z.boolean(),
+	turnOwnerId: z.string().nullable(),
+	phase: z.enum(['idle', 'rolling', 'tile']),
+	activeTilePosition: z.number().int().nonnegative().nullable(),
+	activeTileTrigger: z.enum(['landing', 'moveStart']).nullable(),
+	activeTileSessionId: z.number().int().nonnegative(),
+	diceValue: z.number().int().min(1).max(6).nullable(),
+	tileState: z.record(z.string(), z.unknown()).nullable(),
+	inGame: z.boolean(),
+	spacebarTooltipShown: z.boolean(),
+	version: z.number(),
+	versionAvailable: z.string().nullable()
+});
+
+export const gameStateUpdateSchema = z.object({
+	actorId: z.string(),
+	state: gameStateSchema
+});
+
+export const gameRollRequestSchema = z.object({
+	actorId: z.string()
+});
+
+export type GameState = z.infer<typeof gameStateSchema>;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,12 +1,17 @@
 {
-	"compilerOptions": {
-		"target": "ES2022",
-		"module": "NodeNext",
-		"moduleResolution": "NodeNext",
-		"strict": true,
-		"esModuleInterop": true,
-		"skipLibCheck": true,
-		"outDir": "dist"
-	},
-	"include": ["src"]
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/__tests__"
+  ]
 }


### PR DESCRIPTION
### Motivation
- Incoming Socket.IO event handlers were accessing properties of incoming `payload` objects without validating their shape, which can throw when payloads are `null` or otherwise malformed and cause intermittent backend crashes.
- Centralizing and validating socket payload shapes reduces the risk of runtime exceptions from untrusted clients and makes the runtime behavior explicit.
- While investigating production instability, repeated `502` responses were observed from `https://api.blackout.beer`, indicating upstream instability that aligns with intermittent crashes.

### Description
- Extracted socket-related Zod schemas into `backend/src/socketPayload.ts` and exported `gameStateSchema`, `gameStateUpdateSchema`, `gameRollRequestSchema`, and `GameState` types for reuse.
- Updated `backend/src/index.ts` Socket.IO handlers to fully validate incoming event payloads with the new schemas before accessing properties, covering `game:state:update` and `game:roll:request`.
- Added unit tests for the new payload schemas in `backend/src/__tests__/socketPayload.test.ts` and a backend `test` script in `backend/package.json`.
- Excluded test files from TypeScript output by updating `backend/tsconfig.json` to avoid leaking tests into `dist`.

### Testing
- Ran backend unit tests with `pnpm --dir backend test` and all schema tests passed.
- Ran type check and build with `pnpm --dir backend check` and `pnpm --dir backend build`, both succeeding without errors.
- Performed production probes with `curl` and observed repeated `502` responses from `https://api.blackout.beer`, indicating production instability during investigation.
- Attempted Playwright e2e requests to the production API which failed due to network/ENETUNREACH errors in the test environment, so browser-based probes were inconclusive.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b44739a048832b94b004b7d2c8af0d)